### PR TITLE
Fix pendantic warning in gcc 7.3

### DIFF
--- a/include/experimental/bits/static_thread_pool.h
+++ b/include/experimental/bits/static_thread_pool.h
@@ -79,7 +79,7 @@ class static_thread_pool
       require(const execution::allocator_t<void>&) const { return {pool_, std::allocator<void>{}}; };
     template<class NewProtoAllocator>
       executor_impl<Blocking, Continuation, Work, NewProtoAllocator>
-        require(const execution::allocator_t<NewProtoAllocator>& a) const { return {pool_, a.value()}; };
+        require(const execution::allocator_t<NewProtoAllocator>& a) const { return {pool_, a.value()}; }
     ProtoAllocator query(const execution::allocator_t<ProtoAllocator>&) const noexcept { return allocator_; }
     ProtoAllocator query(const execution::allocator_t<void>&) const noexcept { return allocator_; }
 


### PR DESCRIPTION

Compiling with -fpedantic results in:
```c++
/include/experimental/bits/static_thread_pool.h:82:105: error: extra ‘;’ [-Werror=pedantic]
         require(const execution::allocator_t<NewProtoAllocator>& a) const { return {pool_, a.value()}; };
                                                                                                         ^
```